### PR TITLE
clarify required vs optional Vulkan extension log message

### DIFF
--- a/nvvk/context.cpp
+++ b/nvvk/context.cpp
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (c) 2023-2025, NVIDIA CORPORATION.  All rights reserved.
  *
@@ -491,10 +492,13 @@ bool nvvk::Context::filterAvailableExtensions(const std::vector<VkExtensionPrope
                       + std::to_string(desiredExtension.specVersion) + ")";
       }
       if(desiredExtension.required)
+      {
         allFound = false;
+      }
+      const char* availability = desiredExtension.required ? "Required" : "Optional";
       nvutils::Logger::getInstance().log(
           desiredExtension.required ? nvutils::Logger::LogLevel::eERROR : nvutils::Logger::LogLevel::eWARNING,
-          "Extension not available: %s %s\n", desiredExtension.extensionName, versionInfo.c_str());
+          "%s extension not available: %s %s\n", availability, desiredExtension.extensionName, versionInfo.c_str());
     }
   }
 


### PR DESCRIPTION
as mentioned in https://github.com/nvpro-samples/vk_slang_editor/issues/3#issuecomment-3802631033

this change does change extension error messages from

Extension not available: VK_KHR_fragment_shader_barycentric 
Extension not available: VK_KHR_acceleration_structure 

to this 

Required extension not available: VK_KHR_fragment_shader_barycentric 
Optional extension not available: VK_KHR_acceleration_structure 

so to have better log messages by  explicitly
telling if a missing Vulkan extension was required or optional
