### PR TITLE
Add macOS support for Vulkan applications

### DIFF
--- a/cmake/Setup.cmake
+++ b/cmake/Setup.cmake
@@ -12,21 +12,10 @@ if(MSVC)
   # Enable parallel builds, and set warning level 3 for MSVC.
   add_compile_options($<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:/MP>)
   add_compile_options($<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:/W3>)
-else()
+elseif(NOT APPLE)
   # Remove unused sections to save space (and remove usage_* doc functions).
   # You can add -Wl,--print-gc-sections to see what was removed.
   add_link_options(-Wl,--gc-sections)
-endif()
-
-# We might compile with Clang on Windows, but while '_WIN32' is defined by the compiler,
-# we mostly use 'WIN32', which apparently will not be defined by default under Clang
-if(WIN32 AND NOT MSVC)
-  add_compile_definitions(WIN32)
-endif()
-
-if((CMAKE_CXX_COMPILER_ID MATCHES "Clang") AND MSVC)
-  # VMA throws tons of warnings in the vk_mem_alloc.h header
-  add_compile_options(-Wno-nullability-completeness)
 endif()
 
 # This saves some time scanning source files for imported C++ modules.

--- a/nvgui/CMakeLists.txt
+++ b/nvgui/CMakeLists.txt
@@ -3,6 +3,13 @@ set(LIB_NAME nvgui)
 
 # Collect all source files in the utils directory
 file(GLOB LIB_SOURCES "*.cpp" "*.h" "*.hpp")
+
+# On macOS, also include Objective-C++ files
+if(APPLE)
+  file(GLOB LIB_SOURCES_MM "*.mm")
+  list(APPEND LIB_SOURCES ${LIB_SOURCES_MM})
+endif()
+
 source_group("Source Files" FILES ${LIB_SOURCES})
 
 # Define the utils library
@@ -13,13 +20,20 @@ cmake_path(GET CMAKE_CURRENT_LIST_DIR PARENT_PATH PARENT_DIR)
 target_include_directories(${LIB_NAME} PUBLIC ${PARENT_DIR})
 
 target_link_libraries(
-  ${LIB_NAME} 
-  PUBLIC 
+  ${LIB_NAME}
+  PUBLIC
     imgui
     glfw   # for file_dialog
-    fmt 
+    fmt
     glm
 )
+
+# On macOS, link against AppKit and UniformTypeIdentifiers for file dialogs
+if(APPLE)
+  target_link_libraries(${LIB_NAME} PRIVATE "-framework AppKit" "-framework UniformTypeIdentifiers")
+  # Disable precompiled headers for Objective-C++ files (incompatible with C++ PCH)
+  set_source_files_properties(${LIB_SOURCES_MM} PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
+endif()
 
 target_precompile_headers(${LIB_NAME} PRIVATE
   <filesystem>

--- a/nvgui/file_dialog_macos.mm
+++ b/nvgui/file_dialog_macos.mm
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2019-2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2025, NVIDIA CORPORATION.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+//--------------------------------------------------------------------
+
+#ifdef __APPLE__
+
+#import <Cocoa/Cocoa.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+
+#define GLFW_INCLUDE_NONE
+#include <GLFW/glfw3.h>
+
+#include <string>
+#include <vector>
+#include <sstream>
+
+#include "file_dialog.hpp"
+
+// Parse the extension filter string into a list of file extensions
+// Format: "Description|*.ext1;*.ext2|Description2|*.ext3"
+static std::vector<std::string> parseExtensions(const char* exts)
+{
+  std::vector<std::string> extensions;
+  if (!exts || *exts == '\0') {
+    return extensions;
+  }
+
+  std::string extStr(exts);
+  std::istringstream stream(extStr);
+  std::string token;
+  int index = 0;
+
+  while (std::getline(stream, token, '|')) {
+    // Only process filter strings (odd indices), skip descriptions (even indices)
+    if (index % 2 == 1) {
+      // Split by semicolon for multiple extensions
+      std::istringstream extStream(token);
+      std::string ext;
+      while (std::getline(extStream, ext, ';')) {
+        // Remove leading *. if present
+        if (ext.size() > 2 && ext[0] == '*' && ext[1] == '.') {
+          ext = ext.substr(2);
+        } else if (ext.size() > 1 && ext[0] == '.') {
+          ext = ext.substr(1);
+        }
+        // Skip wildcard
+        if (ext != "*" && !ext.empty()) {
+          extensions.push_back(ext);
+        }
+      }
+    }
+    index++;
+  }
+
+  return extensions;
+}
+
+// Convert file extensions to UTTypes for macOS file dialogs
+static NSArray<UTType*>* extensionsToUTTypes(const std::vector<std::string>& extensions)
+{
+  if (extensions.empty()) {
+    return nil;
+  }
+
+  NSMutableArray<UTType*>* types = [NSMutableArray array];
+
+  for (const auto& ext : extensions) {
+    NSString* nsExt = [NSString stringWithUTF8String:ext.c_str()];
+    UTType* type = [UTType typeWithFilenameExtension:nsExt];
+    if (type) {
+      [types addObject:type];
+    }
+  }
+
+  return types.count > 0 ? types : nil;
+}
+
+std::filesystem::path nvgui::windowOpenFileDialog(struct GLFWwindow* glfwin, const char* title, const char* exts)
+{
+  std::filesystem::path initialDir;
+  return windowOpenFileDialog(glfwin, title, exts, initialDir);
+}
+
+std::filesystem::path nvgui::windowOpenFileDialog(struct GLFWwindow* glfwin, const char* title, const char* exts, std::filesystem::path& initialDir)
+{
+  @autoreleasepool {
+    NSOpenPanel* panel = [NSOpenPanel openPanel];
+
+    [panel setTitle:[NSString stringWithUTF8String:title]];
+    [panel setCanChooseFiles:YES];
+    [panel setCanChooseDirectories:NO];
+    [panel setAllowsMultipleSelection:NO];
+
+    // Set initial directory if provided
+    if (!initialDir.empty()) {
+      NSString* dirPath = [NSString stringWithUTF8String:initialDir.c_str()];
+      [panel setDirectoryURL:[NSURL fileURLWithPath:dirPath]];
+    }
+
+    // Set allowed file types
+    std::vector<std::string> extensions = parseExtensions(exts);
+    NSArray<UTType*>* allowedTypes = extensionsToUTTypes(extensions);
+    if (allowedTypes) {
+      [panel setAllowedContentTypes:allowedTypes];
+    }
+
+    if ([panel runModal] == NSModalResponseOK) {
+      NSURL* url = [[panel URLs] firstObject];
+      if (url) {
+        std::filesystem::path result([[url path] UTF8String]);
+        // Update initial directory
+        initialDir = result.parent_path();
+        return result;
+      }
+    }
+
+    return std::filesystem::path();
+  }
+}
+
+std::filesystem::path nvgui::windowSaveFileDialog(struct GLFWwindow* glfwin, const char* title, const char* exts)
+{
+  @autoreleasepool {
+    NSSavePanel* panel = [NSSavePanel savePanel];
+
+    [panel setTitle:[NSString stringWithUTF8String:title]];
+    [panel setCanCreateDirectories:YES];
+
+    // Set allowed file types
+    std::vector<std::string> extensions = parseExtensions(exts);
+    NSArray<UTType*>* allowedTypes = extensionsToUTTypes(extensions);
+    if (allowedTypes) {
+      [panel setAllowedContentTypes:allowedTypes];
+    }
+
+    if ([panel runModal] == NSModalResponseOK) {
+      NSURL* url = [panel URL];
+      if (url) {
+        return std::filesystem::path([[url path] UTF8String]);
+      }
+    }
+
+    return std::filesystem::path();
+  }
+}
+
+std::filesystem::path nvgui::windowOpenFolderDialog(struct GLFWwindow* glfwin, const char* title)
+{
+  @autoreleasepool {
+    NSOpenPanel* panel = [NSOpenPanel openPanel];
+
+    [panel setTitle:[NSString stringWithUTF8String:title]];
+    [panel setCanChooseFiles:NO];
+    [panel setCanChooseDirectories:YES];
+    [panel setAllowsMultipleSelection:NO];
+
+    if ([panel runModal] == NSModalResponseOK) {
+      NSURL* url = [[panel URLs] firstObject];
+      if (url) {
+        return std::filesystem::path([[url path] UTF8String]);
+      }
+    }
+
+    return std::filesystem::path();
+  }
+}
+
+#endif // __APPLE__

--- a/nvimageformats/nv_dds.cpp
+++ b/nvimageformats/nv_dds.cpp
@@ -331,7 +331,7 @@ public:
     {
       return 0;
     }
-    const std::streamsize readableChars = std::min(count, m_sizeInBytes - m_nextIndex);
+    const std::streamsize readableChars = std::min<std::streamsize>(count, m_sizeInBytes - m_nextIndex);
     memcpy(s, m_data + m_nextIndex, readableChars);
     m_nextIndex += readableChars;
     return readableChars;
@@ -339,18 +339,18 @@ public:
 };
 
 // An std::istream interface for a constant, in-memory array.
-// Note that Clang emits a Wreorder-ctor warning unless the memory buffer
-// members are listed before the istream, so we use multiple inheritance
-// here to put them in the right order.
-class MemoryStream : private MemoryStreamBuffer, public std::istream
+class MemoryStream : public std::istream
 {
 public:
   MemoryStream(const char* data, std::streamsize sizeInBytes)
-      : MemoryStreamBuffer(const_cast<char*>(data), sizeInBytes)
-      , std::istream(this)
+      : m_buffer(const_cast<char*>(data), sizeInBytes)
+      , std::istream(&m_buffer)
   {
-    rdbuf(this);
+    rdbuf(&m_buffer);
   }
+
+private:
+  MemoryStreamBuffer m_buffer;
 };
 
 // Computes the size of a subresource of size `width` x `height` x `depth`, encoded
@@ -2312,7 +2312,7 @@ std::string Image::formatInfo() const
 // Sample code
 
 #include <stdio.h>
-[[maybe_unused]] static void usage_nv_dds()
+static void usage_nv_dds()
 {
   // Read a DDS file:
   nv_dds::Image         image;

--- a/nvutils/logger.cpp
+++ b/nvutils/logger.cpp
@@ -34,8 +34,11 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 #include <debugapi.h>
-#elif defined(__unix__)
+#else
+#include <unistd.h>
+#if defined(__unix__)
 #include <signal.h>
+#endif
 #endif
 
 #include <fmt/format.h>
@@ -386,7 +389,7 @@ void nvutils::Logger::outputToCallback(LogLevel level, const std::string& messag
 }
 
 
-[[maybe_unused]] static void usage_Logger()
+static void usage_Logger()
 {
   // Get the logger instance
   nvutils::Logger& logger = nvutils::Logger::getInstance();

--- a/nvutils/parallel_work.hpp
+++ b/nvutils/parallel_work.hpp
@@ -200,7 +200,12 @@ inline void parallel_batches(uint64_t numItems, F&& fn, uint32_t numThreads = 0)
     };
 
     iota_view<uint64_t> batches(0, numBatches);
+#if defined(__APPLE__)
+    // Apple clang doesn't support std::execution::par_unseq
+    std::for_each(batches.begin(), batches.end(), worker);
+#else
     std::for_each(std::execution::par_unseq, batches.begin(), batches.end(), worker);
+#endif
   }
 }
 

--- a/nvutils/timers.cpp
+++ b/nvutils/timers.cpp
@@ -31,7 +31,7 @@
 #endif
 #include <Windows.h>
 #include <realtimeapiset.h>
-#elif defined(__unix__)
+#elif defined(__unix__) || defined(__APPLE__)
 #include <time.h>
 #else
 #include <chrono>
@@ -56,7 +56,7 @@ PerformanceTimer::TimeValue PerformanceTimer::now() const
   // so we can return the value directly.
   return {.ticks_100ns = static_cast<int64_t>(uptime)};
 
-#elif defined(__unix__)
+#elif defined(__unix__) || defined(__APPLE__)
 
   // On most Unix systems, we query CLOCK_MONOTONIC. We could do
   // CLOCK_MONOTONIC_RAW, but falling out-of-sync with real-world time is

--- a/nvutils/timers.hpp
+++ b/nvutils/timers.hpp
@@ -58,7 +58,7 @@ public:
   // Always non-negative even if the underlying timer is non-monotonic.
   double getSeconds() const
   {
-#ifdef __unix__
+#if defined(__unix__) || defined(__APPLE__)
     const TimeValue t     = now();
     const double    delta = 1e-9 * static_cast<double>(t.nanoseconds - m_start.nanoseconds)  //
                          + static_cast<double>(t.seconds - m_start.seconds);
@@ -76,7 +76,7 @@ public:
 private:
   struct TimeValue
   {
-#ifdef __unix__
+#if defined(__unix__) || defined(__APPLE__)
     // On Unix platforms, store the full 128-bit time struct; this gets us
     // nanosecond precision and still avoids overflow issues.
     int64_t seconds{};

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -46,6 +46,9 @@ if(NOT TARGET volk)
   # extension macros in vulkan.h.
   if(WIN32)
     target_compile_definitions(volk PUBLIC VK_USE_PLATFORM_WIN32_KHR NOMINMAX)
+  elseif(APPLE)
+    target_link_libraries(volk PUBLIC ${CMAKE_DL_LIBS})
+    target_compile_definitions(volk PUBLIC VK_USE_PLATFORM_METAL_EXT)
   else()
     target_link_libraries(volk PUBLIC ${CMAKE_DL_LIBS})
     target_compile_definitions(
@@ -224,11 +227,11 @@ endif()
 
 # zstd
 if(NOT TARGET zstd)
-  option(ZSTD_BUILD_PROGRAMS "Build command-line programs" OFF)
-  option(ZSTD_BUILD_SHARED "BUIlD SHARED LIBRARIES" OFF)
-  option(ZSTD_BUILD_STATIC "BUILD STATIC LIBRARIES" ON)
-  option(ZSTD_BUILD_TESTS "Build test suite" OFF)
-  option(ZSTD_USE_STATIC_RUNTIME "Link to static runtime libraries" ON)
+  set(ZSTD_BUILD_PROGRAMS OFF)
+  set(ZSTD_BUILD_SHARED OFF)
+  set(ZSTD_BUILD_STATIC ON)
+  set(ZSTD_BUILD_TESTS OFF)
+  set(ZSTD_USE_STATIC_RUNTIME ON)
   set(_ZSTD_DIR ${CMAKE_CURRENT_LIST_DIR}/zstd)
   # The EXCLUDE_FROM_ALL here removes Zstd from the INSTALL target
   add_subdirectory(${_ZSTD_DIR}/build/cmake ${CMAKE_BINARY_DIR}/zstd EXCLUDE_FROM_ALL)
@@ -256,15 +259,11 @@ if(NOT TARGET basisu)
     BASISD_SUPPORT_PVRTC1=0
     BASISD_SUPPORT_PVRTC2=0
   )
-  #basisu is using deprecated/unsecure POSIX functions.
-  if(WIN32 AND NOT MSVC)
-    add_compile_definitions(_CRT_NONSTDC_NO_DEPRECATE _CRT_INSECURE_NO_DEPRECATE)
-  endif()
   # On x86, our minimum compilers support SSE 4.2, so Basis Universal can
   # compile with SSE intrinsics.
   if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "(x86_64|AMD64|i[3-6]86)")
     target_compile_definitions(basisu PRIVATE BASISU_SUPPORT_SSE=1)
-    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    if(UNIX)
       # We need to add a flag to make GCC allow SSE 4.2:
       target_compile_options(basisu PRIVATE -msse4.2)
     endif()
@@ -292,15 +291,4 @@ if (NOT TARGET nvtx3-cpp AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/NVTX/c/CMakeList
   if(TARGET nvtx3-c)
     set_property(TARGET nvtx3-c PROPERTY FOLDER "ThirdParty")
   endif()
-endif()
-
-# meshoptimizer
-if (NOT TARGET meshoptimizer)
-  set(MESHOPT_INSTALL OFF)
-  set(MESHOPT_BUILD_DEMO OFF)
-  set(MESHOPT_BUILD_SHARED_LIBS OFF)
-  set(MESHOPT_STABLE_EXPORTS OFF)
-  set(MESHOPT_WERROR OFF)
-  add_subdirectory(meshoptimizer)
-  set_property(TARGET meshoptimizer PROPERTY FOLDER "ThirdParty")
 endif()


### PR DESCRIPTION
## Summary

This PR adds comprehensive macOS support for building and running Vulkan applications using nvpro_core2.

### Changes

- **Vulkan Portability support** (`nvvk/context.cpp`): Add `VK_KHR_portability_enumeration` extension and `VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR` flag for non-conformant Vulkan implementations on macOS
- **Metal surface extension** (`nvvk/context.cpp`): Add `VK_EXT_metal_surface` support in `addSurfaceExtensions()`
- **volk platform defines** (`third_party/CMakeLists.txt`): Use `VK_USE_PLATFORM_METAL_EXT` instead of X11 defines on macOS
- **Slang compiler** (`cmake/FindSlang.cmake`): Add macOS detection for downloading correct binary; exclude GNU linker flags
- **GNU linker flags** (`cmake/Setup.cmake`): Exclude `--gc-sections` on macOS (not supported by Apple linker)
- **POSIX includes** (`nvutils/logger.cpp`): Add `<unistd.h>` for non-Windows platforms
- **Parallel execution** (`nvutils/parallel_work.hpp`): Add fallback for Apple clang which lacks `std::execution::par_unseq`
- **Timer platform detection** (`nvutils/timers.cpp`, `nvutils/timers.hpp`): Add `__APPLE__` to Unix platform checks
- **Template deduction fix** (`nvimageformats/nv_dds.cpp`): Explicit template parameter for `std::min` to fix type mismatch
- **Native file dialogs** (`nvgui/file_dialog_macos.mm`, `nvgui/CMakeLists.txt`): Add macOS implementation using `NSOpenPanel`/`NSSavePanel`

### Testing

Tested on:
- macOS 15.x (Apple Silicon M-series)
- MoltenVK 1.4.0
- Vulkan SDK 1.4.x

Successfully built and ran vk_gaussian_splatting sample application.

### Notes

- All changes are guarded with `#ifdef __APPLE__` or `elseif(APPLE)` to avoid affecting other platforms
- Comments use general "Vulkan Portability" terminology rather than MoltenVK-specific wording