### PR TITLE
fixes missing include

### DIFF
--- a/nvvk/swapchain.cpp
+++ b/nvvk/swapchain.cpp
@@ -19,6 +19,8 @@
 
 #include "nvutils/logger.hpp"
 
+#include <algorithm>
+
 #include "commands.hpp"
 #include "barriers.hpp"
 #include "check_error.hpp"


### PR DESCRIPTION
On my system with vulkan 1.4.350 and gcc 14.2, the algorithm header was missing for std::max and std::clamp. std::vector is already covered by the header.